### PR TITLE
Improve batch CLI with dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,16 @@
 - docs(review): add comprehensive code review
 - Update README.md
 - Initial commit
+
+## Unreleased
+
+- Add `BatchProcessor` for directory processing
+- Document batch processing feature
+- Add CLI utilities for summarizing documents and compliance reporting
+- Package CLI scripts under `hipaa_compliance_summarizer.cli` with console
+  entry points
+- Add `--show-dashboard` option to `hipaa-batch-process`
+- Batch dashboard provides friendly string output for CLI
+- Rename batch process flag to `--compliance-level` for consistency
+- Add `--dashboard-json` option to save dashboard metrics as JSON
+- Provide `BatchProcessor.save_dashboard` helper for exporting metrics

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Healthcare-focused LLM agent that automatically redacts PHI (Protected Health In
 - **Compliance Reporting**: Generates detailed compliance summaries and audit trails
 - **Healthcare Document Types**: Specialized handling for medical records, clinical notes, insurance forms
 - **Risk Assessment**: Identifies potential HIPAA violations and compliance gaps
-- **Batch Processing**: Handle large volumes of healthcare documents securely
+- **Batch Processing**: Handle large volumes of healthcare documents securely using `BatchProcessor`
 
 ## Quick Start
 
@@ -18,14 +18,26 @@ Healthcare-focused LLM agent that automatically redacts PHI (Protected Health In
 pip install -r requirements.txt
 pip install hipaa-ml-toolkit
 
+
 # Process a single medical document
-python summarize.py --file patient_record.pdf --redact-phi
+hipaa-summarize --file patient_record.pdf --compliance-level strict
 
 # Batch process medical records
-python batch_process.py --input-dir ./medical_records --compliance-check
+hipaa-batch-process \
+  --input-dir ./medical_records \
+  --output-dir ./redacted_records \
+  --compliance-level standard \
+  --generate-summaries \
+  --show-dashboard \
+  --dashboard-json dashboard.json
+
+# Example dashboard output
+Documents processed: 20
+Average compliance score: 0.98
+Total PHI detected: 75
 
 # Generate compliance report
-python compliance_report.py --audit-period "2024-Q1"
+hipaa-compliance-report --audit-period "2024-Q1"
 ```
 
 ## HIPAA Compliance Features
@@ -88,7 +100,7 @@ output:
 
 ### Basic PHI Redaction
 ```python
-from hipaa_summarizer import HIPAAProcessor
+from hipaa_compliance_summarizer import HIPAAProcessor
 
 processor = HIPAAProcessor(compliance_level="strict")
 result = processor.process_document("patient_chart.pdf")
@@ -117,7 +129,7 @@ print(result.summary)
 
 ### Compliance Reporting
 ```python
-from hipaa_summarizer import ComplianceReporter
+from hipaa_compliance_summarizer import ComplianceReporter
 
 reporter = ComplianceReporter()
 report = reporter.generate_report(
@@ -135,18 +147,19 @@ print(report.recommendations)
 
 ### Batch Processing
 ```python
-from hipaa_summarizer import BatchProcessor
+from hipaa_compliance_summarizer import BatchProcessor
 
 processor = BatchProcessor()
 results = processor.process_directory(
     "./medical_records",
     output_dir="./processed_records",
-    redaction_level="high",
+    compliance_level="strict",
     generate_summaries=True
 )
 
 # Generate compliance dashboard
 dashboard = processor.generate_dashboard(results)
+processor.save_dashboard(results, "dashboard.json")
 ```
 
 ## Document Types Supported
@@ -277,7 +290,7 @@ processor.add_clinical_rule(
 ### Integration with EHR Systems
 ```python
 # Epic EHR integration
-from hipaa_summarizer.integrations import EpicConnector
+from hipaa_compliance_summarizer.integrations import EpicConnector
 
 epic = EpicConnector(api_key="your_epic_key")
 records = epic.fetch_patient_records(patient_id="12345")
@@ -287,7 +300,7 @@ processed = processor.process_ehr_batch(records)
 ### Audit and Monitoring
 ```python
 # Real-time compliance monitoring
-from hipaa_summarizer import ComplianceMonitor
+from hipaa_compliance_summarizer import ComplianceMonitor
 
 monitor = ComplianceMonitor()
 monitor.start_real_time_monitoring(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,12 @@ requires-python = ">=3.8"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["hipaa_compliance_summarizer"]
+packages = [
+    "hipaa_compliance_summarizer",
+    "hipaa_compliance_summarizer.cli",
+]
+
+[project.scripts]
+hipaa-summarize = "hipaa_compliance_summarizer.cli.summarize:main"
+hipaa-batch-process = "hipaa_compliance_summarizer.cli.batch_process:main"
+hipaa-compliance-report = "hipaa_compliance_summarizer.cli.compliance_report:main"

--- a/src/hipaa_compliance_summarizer/__init__.py
+++ b/src/hipaa_compliance_summarizer/__init__.py
@@ -1,6 +1,7 @@
 from .phi import PHIRedactor, RedactionResult, Entity
 from .processor import HIPAAProcessor, ProcessingResult, ComplianceLevel
 from .reporting import ComplianceReporter, ComplianceReport
+from .batch import BatchProcessor, BatchDashboard
 from .documents import DocumentType, Document, detect_document_type
 from .parsers import (
     parse_medical_record,
@@ -23,4 +24,6 @@ __all__ = [
     "parse_medical_record",
     "parse_clinical_note",
     "parse_insurance_form",
+    "BatchProcessor",
+    "BatchDashboard",
 ]

--- a/src/hipaa_compliance_summarizer/batch.py
+++ b/src/hipaa_compliance_summarizer/batch.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence, Optional
+
+from .documents import Document, detect_document_type
+from .processor import HIPAAProcessor, ProcessingResult, ComplianceLevel
+
+
+@dataclass
+class BatchDashboard:
+    """Simple summary of batch processing results."""
+
+    documents_processed: int
+    avg_compliance_score: float
+    total_phi_detected: int
+
+    def __str__(self) -> str:
+        return (
+            f"Documents processed: {self.documents_processed}\n"
+            f"Average compliance score: {self.avg_compliance_score}\n"
+            f"Total PHI detected: {self.total_phi_detected}"
+        )
+
+    def to_dict(self) -> dict[str, float | int]:
+        """Return a dictionary representation of the dashboard."""
+        return {
+            "documents_processed": self.documents_processed,
+            "avg_compliance_score": self.avg_compliance_score,
+            "total_phi_detected": self.total_phi_detected,
+        }
+
+    def to_json(self) -> str:
+        """Return a JSON string representation of the dashboard."""
+        import json
+
+        return json.dumps(self.to_dict(), indent=2)
+
+
+class BatchProcessor:
+    """Process directories of healthcare documents."""
+
+    def __init__(self, compliance_level: ComplianceLevel = ComplianceLevel.STANDARD) -> None:
+        self.processor = HIPAAProcessor(compliance_level=compliance_level)
+
+    def process_directory(
+        self,
+        input_dir: str,
+        *,
+        output_dir: Optional[str] = None,
+        compliance_level: Optional[str] = None,
+        generate_summaries: bool = False,
+    ) -> List[ProcessingResult]:
+        """Process all files in ``input_dir`` and optionally write outputs."""
+        if compliance_level is not None:
+            # allow caller to override compliance level
+            self.processor.compliance_level = ComplianceLevel(compliance_level)
+
+        results: List[ProcessingResult] = []
+        in_path = Path(input_dir)
+        out_path = Path(output_dir) if output_dir else None
+        if out_path:
+            out_path.mkdir(parents=True, exist_ok=True)
+
+        for file in in_path.iterdir():
+            if not file.is_file():
+                continue
+            doc_type = detect_document_type(file.name)
+            doc = Document(str(file), doc_type)
+            result = self.processor.process_document(doc)
+            results.append(result)
+
+            if out_path:
+                out_file = out_path / file.name
+                out_file.write_text(result.redacted.text)
+                if generate_summaries:
+                    summary_file = out_file.with_suffix(out_file.suffix + ".summary.txt")
+                    summary_file.write_text(result.summary)
+
+        return results
+
+    def generate_dashboard(self, results: Sequence[ProcessingResult]) -> BatchDashboard:
+        """Create a dashboard summary for ``results``."""
+        if results:
+            avg_score = sum(r.compliance_score for r in results) / len(results)
+            total_phi = sum(r.phi_detected_count for r in results)
+        else:
+            avg_score = 1.0
+            total_phi = 0
+        return BatchDashboard(
+            documents_processed=len(results),
+            avg_compliance_score=round(avg_score, 2),
+            total_phi_detected=total_phi,
+        )
+
+    def save_dashboard(self, results: Sequence[ProcessingResult], path: str) -> None:
+        """Write a dashboard summary for ``results`` to ``path`` as JSON."""
+        dash = self.generate_dashboard(results)
+        Path(path).write_text(dash.to_json())

--- a/src/hipaa_compliance_summarizer/cli/__init__.py
+++ b/src/hipaa_compliance_summarizer/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line utilities for hipaa-compliance-summarizer."""

--- a/src/hipaa_compliance_summarizer/cli/batch_process.py
+++ b/src/hipaa_compliance_summarizer/cli/batch_process.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""Example script to batch process healthcare documents."""
+from argparse import ArgumentParser
+from hipaa_compliance_summarizer import BatchProcessor
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Batch process healthcare documents")
+    parser.add_argument("--input-dir", required=True, help="Input directory of documents")
+    parser.add_argument("--output-dir", required=True, help="Directory to write processed files")
+    parser.add_argument(
+        "--compliance-level",
+        choices=["strict", "standard", "minimal"],
+        default="standard",
+        help="Compliance strictness level",
+    )
+    parser.add_argument(
+        "--generate-summaries",
+        action="store_true",
+        help="Write summary files alongside redacted text",
+    )
+    parser.add_argument(
+        "--show-dashboard",
+        action="store_true",
+        help="Print batch processing summary after completion",
+    )
+    parser.add_argument(
+        "--dashboard-json",
+        help="Write dashboard summary to a JSON file",
+    )
+    args = parser.parse_args()
+
+    processor = BatchProcessor()
+    results = processor.process_directory(
+        args.input_dir,
+        output_dir=args.output_dir,
+        compliance_level=args.compliance_level,
+        generate_summaries=args.generate_summaries,
+    )
+
+    dash = None
+    if args.show_dashboard:
+        dash = processor.generate_dashboard(results)
+        print(dash)
+
+    if args.dashboard_json:
+        if dash is None:
+            dash = processor.generate_dashboard(results)
+        processor.save_dashboard(results, args.dashboard_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hipaa_compliance_summarizer/cli/compliance_report.py
+++ b/src/hipaa_compliance_summarizer/cli/compliance_report.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Generate a simple compliance report."""
+from argparse import ArgumentParser
+from hipaa_compliance_summarizer import ComplianceReporter
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Generate compliance report")
+    parser.add_argument("--audit-period", required=True, help="Reporting period")
+    parser.add_argument("--documents-processed", type=int, default=0)
+    parser.add_argument("--include-recommendations", action="store_true")
+    args = parser.parse_args()
+
+    reporter = ComplianceReporter()
+    report = reporter.generate_report(
+        period=args.audit_period,
+        documents_processed=args.documents_processed,
+        include_recommendations=args.include_recommendations,
+    )
+    print(report.overall_compliance)
+    print(report.recommendations)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hipaa_compliance_summarizer/cli/summarize.py
+++ b/src/hipaa_compliance_summarizer/cli/summarize.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Example script to process a single medical document."""
+from argparse import ArgumentParser
+from hipaa_compliance_summarizer import HIPAAProcessor
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Summarize a medical document")
+    parser.add_argument("--file", required=True, help="Path to the document")
+    parser.add_argument(
+        "--compliance-level",
+        choices=["strict", "standard", "minimal"],
+        default="standard",
+        help="Compliance strictness level",
+    )
+    args = parser.parse_args()
+
+    processor = HIPAAProcessor(compliance_level=args.compliance_level)
+    result = processor.process_document(args.file)
+    print(result.summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -1,0 +1,31 @@
+from hipaa_compliance_summarizer import BatchProcessor
+
+
+def test_batch_processor(tmp_path):
+    (tmp_path / "a.txt").write_text("Patient: John Doe")
+    (tmp_path / "b.txt").write_text("SSN: 123-45-6789")
+
+    proc = BatchProcessor()
+    results = proc.process_directory(str(tmp_path))
+    assert len(results) == 2
+
+    dashboard = proc.generate_dashboard(results)
+    assert dashboard.documents_processed == 2
+    assert dashboard.total_phi_detected >= 1
+    dash_str = str(dashboard)
+    assert "Documents processed:" in dash_str
+    dash_dict = dashboard.to_dict()
+    assert dash_dict["documents_processed"] == 2
+    dash_json = dashboard.to_json()
+    assert "documents_processed" in dash_json
+
+
+def test_save_dashboard(tmp_path):
+    (tmp_path / "a.txt").write_text("A")
+    proc = BatchProcessor()
+    results = proc.process_directory(str(tmp_path))
+    out_file = tmp_path / "dash.json"
+    proc.save_dashboard(results, out_file)
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert "documents_processed" in content

--- a/tests/test_cli_batch_process.py
+++ b/tests/test_cli_batch_process.py
@@ -1,0 +1,42 @@
+import sys
+from hipaa_compliance_summarizer.cli import batch_process
+
+
+def test_cli_batch_process(tmp_path, capsys, monkeypatch):
+    (tmp_path / "a.txt").write_text("Name: Jane Doe")
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(sys, "argv", [
+        "batch_process",
+        "--input-dir", str(tmp_path),
+        "--output-dir", str(out_dir),
+        "--show-dashboard",
+        "--dashboard-json",
+        str(tmp_path / "dash.json"),
+    ])
+    batch_process.main()
+    captured = capsys.readouterr()
+    assert out_dir.exists()
+    assert "Documents processed:" in captured.out
+    json_path = tmp_path / "dash.json"
+    assert json_path.exists()
+
+
+def test_cli_dashboard_json_only(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("Name: Joe")
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "batch_process",
+            "--input-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out_dir),
+            "--dashboard-json",
+            str(tmp_path / "dash.json"),
+        ],
+    )
+    batch_process.main()
+    assert out_dir.exists()
+    assert (tmp_path / "dash.json").exists()

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -1,0 +1,10 @@
+import tomllib
+
+
+def test_cli_scripts_defined():
+    with open("pyproject.toml", "rb") as fh:
+        data = tomllib.load(fh)
+    scripts = data.get("project", {}).get("scripts", {})
+    assert scripts.get("hipaa-summarize")
+    assert scripts.get("hipaa-batch-process")
+    assert scripts.get("hipaa-compliance-report")


### PR DESCRIPTION
## Summary
- add `BatchProcessor.save_dashboard` to easily write dashboard metrics
- update CLI to reuse the new dashboard helper
- demonstrate saving a dashboard in the README
- document the new helper in the changelog
- extend tests for dashboard saving and CLI JSON output

## Testing
- `ruff check .`
- `bandit -r src`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e87e56d0883299cd6b46482497bdb

## Summary by Sourcery

Implement batch processing dashboard support by adding BatchProcessor.save_dashboard and related dashboard generation API, extend the CLI with --show-dashboard and --dashboard-json options, update documentation and tests, and register new console scripts.

New Features:
- Add BatchProcessor with directory processing and dashboard generation
- Add BatchProcessor.save_dashboard for exporting dashboard metrics as JSON
- Introduce console scripts: hipaa-summarize, hipaa-batch-process, and hipaa-compliance-report

Enhancements:
- Add --show-dashboard and --dashboard-json options to the batch processing CLI
- Rename batch redaction flag to --compliance-level for consistency
- Consolidate CLI code under hipaa_compliance_summarizer.cli module

Build:
- Update pyproject.toml to include cli package and define console scripts

Documentation:
- Update README with dashboard usage examples
- Document new dashboard helper in CHANGELOG

Tests:
- Add unit tests for batch processor dashboard generation and JSON export
- Add CLI tests for batch processing output and entry point definitions